### PR TITLE
Wildcard errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ $quest->put($path, $callback);      # Add a PUT route.
 
 # Error method
 $quest->error($status, $callback);  # Add or run an error callback; will run an already defined
-                                    # (wildcard first!) or default callback if no $callback is supplied.
+                                    # or default callback if no $callback is supplied.
                                     # $status can be a valid status code, a callable, or null (wildcard error).
                                     # $callback must be a callable if supplied.
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ $quest->put($path, $callback);      # Add a PUT route.
 
 # Error method
 $quest->error($status, $callback);  # Add or run an error callback; will run an already defined
-                                    # or default callback if no $callback is supplied.
-                                    # $status must be an integer and valid status code and
+                                    # (wildcard first!) or default callback if no $callback is supplied.
+                                    # $status can be a valid status code, a callable, or null (wildcard error).
                                     # $callback must be a callable if supplied.
 
 # Helper methods

--- a/src/oscarpalmer/Quest/Item.php
+++ b/src/oscarpalmer/Quest/Item.php
@@ -52,7 +52,11 @@ class Item
             return;
         }
 
-        throw new \InvalidArgumentException("Callback must be a callable, " . gettype($callback) . " given.");
+        throw new \InvalidArgumentException(
+            "Callback must be a callable, \"" .
+            gettype($callback) .
+            "\" given."
+        );
     }
 
     /**
@@ -68,6 +72,10 @@ class Item
             return;
         }
 
-        throw new \InvalidArgumentException("Path must be a string, " . gettype($path) . " given.");
+        throw new \InvalidArgumentException(
+            "Path must be a string, \"" .
+            gettype($path) .
+            "\" given."
+        );
     }
 }

--- a/src/oscarpalmer/Quest/Quest.php
+++ b/src/oscarpalmer/Quest/Quest.php
@@ -177,16 +177,20 @@ class Quest
                     }
 
                     throw new \InvalidArgumentException(
-                        "Callback must be a callable, " .
+                        "Callback must be a callable, \"" .
                         gettype($callback) .
-                        " given."
+                        "\" given."
                     );
                 }
 
                 return $this->errorCallback($status);
             }
 
-            throw new \InvalidArgumentException("Status must be a callable or an integer, " . gettype($status) . " given.");
+            throw new \InvalidArgumentException(
+                "Status must be a callable or an integer, \"" .
+                gettype($status) .
+                "\" given."
+            );
         }
 
         return $this->errorCallback();
@@ -278,12 +282,16 @@ class Quest
     public function redirect($location, $status = 302)
     {
         if (is_string($location)) {
-            $this->response->setHeader("Location", $location);
+            $this->response->setHeader("location", $location);
 
             return $this->halt($status);
         }
 
-        throw new \InvalidArgumentException("Location must be a string, " . gettype($location) . " given.");
+        throw new \InvalidArgumentException(
+            "Location must be a string, \"" .
+            gettype($location) .
+            "\" given."
+        );
     }
 
     /**

--- a/src/oscarpalmer/Quest/Quest.php
+++ b/src/oscarpalmer/Quest/Quest.php
@@ -358,10 +358,10 @@ class Quest
 
         $this->response->setStatus($status);
 
-        if (isset($this->errors["*"])) {
-            throw new Exception\Halt(call_user_func($this->errors["*"], $this));
-        } elseif (isset($this->errors[$status])) {
+        if (isset($this->errors[$status])) {
             throw new Exception\Halt(call_user_func($this->errors[$status], $this));
+        } elseif (isset($this->errors["*"])) {
+            throw new Exception\Halt(call_user_func($this->errors["*"], $this));
         } else {
             throw new Exception\Halt($this->response->getStatusMessage());
         }

--- a/tests/oscarpalmer/Quest/Test/QuestTest.php
+++ b/tests/oscarpalmer/Quest/Test/QuestTest.php
@@ -94,6 +94,24 @@ class QuestTest extends \PHPUnit_Framework_TestCase
         session_destroy();
     }
 
+    public function testWildcardError()
+    {
+        $quest = new Quest(array(), new Request($this->simple));
+        $quest->error(function () { return "Custom error."; });
+
+        foreach (array(404, 500, null) as $status) {
+            try {
+                $quest->error($status);
+            } catch (Halt $e) {
+                $this->assertNotNull($e);
+                $this->assertInstanceOf("oscarpalmer\Quest\Exception\Halt", $e);
+                $this->assertSame("Custom error.", $e->getMessage());
+            }
+        }
+
+        session_destroy();
+    }
+
     public function testBadErrors()
     {
         $quest = new Quest(array(), new Request($this->simple));


### PR DESCRIPTION
Wildcard errors can now be defined and run in place of the default error handlers. The default status code is `500`, but it works with all of them unless it already has a custom handler defined.

Tests passes on `>=5.3`.