### PR TITLE
Code coverage by Codecov and tests for 7.n

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+env:
+  global:
+    - CODECOV_TOKEN="c73ead46-ad1d-4daf-aabe-23876c03b55e"
+
 language: php
 
 php:
@@ -5,13 +9,15 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - 7.1
 
 before_script:
-  - composer self-update
-  - composer install
-  - pear install PHP_CodeSniffer
-  - phpenv rehash
+  - travis_retry composer self-update
+  - travis_retry composer install --no-interaction --prefer-source
 
 script:
-  - phpcs --standard=psr2 src/
-  - phpunit --coverage-text
+  - vendor/bin/phpunit --coverage-clover=coverage.xml
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Quest
 
-[![PHP version](https://badge.fury.io/ph/oscarpalmer%2Fquest.png)](http://badge.fury.io/ph/oscarpalmer%2Fquest) [![Build Status](https://travis-ci.org/oscarpalmer/quest.png?branch=master)](https://travis-ci.org/oscarpalmer/quest) [![Coverage Status](https://coveralls.io/repos/oscarpalmer/quest/badge.png?branch=master)](https://coveralls.io/r/oscarpalmer/quest?branch=master)
+[![PHP version](https://badge.fury.io/ph/oscarpalmer%2Fquest.svg)](http://badge.fury.io/ph/oscarpalmer%2Fquest) [![Build Status](https://travis-ci.org/oscarpalmer/quest.png?branch=master)](https://travis-ci.org/oscarpalmer/quest) [![Coverage Status](https://codecov.io/gh/oscarpalmer/quest/branch/master/graph/badge.svg)](https://coveralls.io/r/oscarpalmer/quest?branch=master)
 
 Quest is a router for PHP `>=5.3`.
 
@@ -8,9 +8,7 @@ Quest is a router for PHP `>=5.3`.
 
 > In particular, questing heroes of all stripes seek after the fabled Daedric artifacts for their potent combat and magical benefits.
 
-&mdash; Haderus of Gottlesfont, [Modern Heretics](http://uesp.net/wiki/Lore:Modern_Heretics).
-
-Quests are cool. I like quests and questing.
+&mdash; Haderus of Gottlesfont, _[Modern Heretics](http://uesp.net/wiki/Lore:Modern_Heretics)_
 
 ## Getting started
 

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,6 @@
     "php": ">=5.3.0"
   },
   "require-dev": {
-    "league/phpunit-coverage-listener": "dev-master"
+    "phpunit/phpunit": "~4.0"
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,33 +10,4 @@
       <directory suffix=".php">src/oscarpalmer/Quest</directory>
     </whitelist>
   </filter>
-  <logging>
-    <log type="coverage-clover" target="/tmp/coverage.xml"/>
-  </logging>
-  <listeners>
-    <listener class="League\PHPUnitCoverageListener\Listener">
-      <arguments>
-        <array>
-          <element key="printer">
-            <object class="League\PHPUnitCoverageListener\Printer\StdOut"/>
-          </element>
-          <element key="hook">
-            <object class="League\PHPUnitCoverageListener\Hook\Travis"/>
-          </element>
-          <element key="namespace">
-            <string>oscarpalmer\Quest</string>
-          </element>
-          <element key="repo_token">
-            <string>6dIxCs7qQP6TLL0i5Ot2qMB9ts0cZSX4I</string>
-          </element>
-          <element key="target_url">
-            <string>https://coveralls.io/api/v1/jobs</string>
-          </element>
-          <element key="coverage_dir">
-            <string>/tmp</string>
-          </element>
-        </array>
-      </arguments>
-    </listener>
-  </listeners>
 </phpunit>


### PR DESCRIPTION
Switched from Coveralls to Codecov for code coverage, added `7.0` and `7.1` to the list of versions to run tests on with Travis, and switched to SVG badges for the readme.

Tests passes on `>=5.3`.